### PR TITLE
add AttrMapType to OpEquationContext and NaiveOpEquationContext

### DIFF
--- a/paddle/cinn/adt/naive_op_equation_context.cc
+++ b/paddle/cinn/adt/naive_op_equation_context.cc
@@ -108,8 +108,14 @@ void GenerateOpEquations(const OpStmt& op_stmt,
 std::shared_ptr<config::NaiveOpEquationContext> MakeContextAndGenerateEquations(
     const OpStmt& op_stmt) {
   const auto& [op, inputs, outputs] = op_stmt.tuple();
+
+  CHECK(op.Has<const hlir::framework::Node*>());
+  const hlir::framework::Node* op_node = op.Get<const hlir::framework::Node*>();
+
   const auto& ctx = std::make_shared<config::NaiveOpEquationContext>(
-      MakeTensorRanks(inputs.value()), MakeTensorRanks(outputs.value()));
+      MakeTensorRanks(inputs.value()),
+      MakeTensorRanks(outputs.value()),
+      op_node);
 
   GenerateOpEquations(op_stmt, ctx.get());
 

--- a/paddle/cinn/adt/naive_op_equation_context.cc
+++ b/paddle/cinn/adt/naive_op_equation_context.cc
@@ -111,11 +111,12 @@ std::shared_ptr<config::NaiveOpEquationContext> MakeContextAndGenerateEquations(
 
   CHECK(op.Has<const hlir::framework::Node*>());
   const hlir::framework::Node* op_node = op.Get<const hlir::framework::Node*>();
+  const hlir::framework::AttrMapType& attr_map_type = op_node->attrs.attr_store;
 
   const auto& ctx = std::make_shared<config::NaiveOpEquationContext>(
       MakeTensorRanks(inputs.value()),
       MakeTensorRanks(outputs.value()),
-      op_node);
+      attr_map_type);
 
   GenerateOpEquations(op_stmt, ctx.get());
 

--- a/paddle/cinn/adt/naive_op_equation_context.h
+++ b/paddle/cinn/adt/naive_op_equation_context.h
@@ -36,10 +36,12 @@ class NaiveOpEquationContext final : public OpEquationContext {
 
   explicit NaiveOpEquationContext(
       const std::vector<std::uint64_t>& in_tensors_ranks,
-      const std::vector<std::uint64_t>& out_tensors_ranks)
+      const std::vector<std::uint64_t>& out_tensors_ranks,
+      const hlir::framework::Node* op_node)
       : in_tensors_ranks_(in_tensors_ranks),
         out_tensors_ranks_(out_tensors_ranks),
         equations_{},
+        attr_map_type_(op_node->attrs.attr_store),
         in_msg_box_in_indexes_(MakeArgIndexes(in_tensors_ranks.size())),
         in_msg_box_out_indexes_(MakeArgIndexes(out_tensors_ranks.size())),
         out_msg_box_in_indexes_(MakeArgIndexes(in_tensors_ranks.size())),
@@ -111,6 +113,10 @@ class NaiveOpEquationContext final : public OpEquationContext {
 
   const DimTuple& GetOutDimTuple(std::size_t output_idx) const override {
     return out_dim_tuples_.at(output_idx);
+  }
+
+  const hlir::framework::AttrMapType& GetAttrMapType() const override {
+    return attr_map_type_;
   }
 
   const Equations& equations() const { return equations_; }
@@ -298,6 +304,8 @@ class NaiveOpEquationContext final : public OpEquationContext {
   std::vector<StrideTuple> out_stride_tuples_;
   std::vector<DimTuple> in_dim_tuples_;
   std::vector<DimTuple> out_dim_tuples_;
+
+  hlir::framework::AttrMapType attr_map_type_;
 
   FakeOpPlaceHolder fake_op_placeholder_;
 };

--- a/paddle/cinn/adt/naive_op_equation_context.h
+++ b/paddle/cinn/adt/naive_op_equation_context.h
@@ -37,11 +37,11 @@ class NaiveOpEquationContext final : public OpEquationContext {
   explicit NaiveOpEquationContext(
       const std::vector<std::uint64_t>& in_tensors_ranks,
       const std::vector<std::uint64_t>& out_tensors_ranks,
-      const hlir::framework::Node* op_node)
+      const hlir::framework::AttrMapType& attr_map_type)
       : in_tensors_ranks_(in_tensors_ranks),
         out_tensors_ranks_(out_tensors_ranks),
         equations_{},
-        attr_map_type_(op_node->attrs.attr_store),
+        attr_map_type_(attr_map_type),
         in_msg_box_in_indexes_(MakeArgIndexes(in_tensors_ranks.size())),
         in_msg_box_out_indexes_(MakeArgIndexes(out_tensors_ranks.size())),
         out_msg_box_in_indexes_(MakeArgIndexes(in_tensors_ranks.size())),

--- a/paddle/cinn/adt/op_equation_context.h
+++ b/paddle/cinn/adt/op_equation_context.h
@@ -59,6 +59,8 @@ class OpEquationContext {
 
   virtual const DimTuple& GetOutDimTuple(std::size_t output_idx) const = 0;
 
+  virtual const hlir::framework::AttrMapType& GetAttrMapType() const = 0;
+
  protected:
   OpEquationContext() = default;
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
Others
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others
<!-- One of [ OPs | APIs | Docs | Others ] -->

add AttrMapType to OpEquationContext and NaiveOpEquationContext
<!-- Describe what you’ve done -->
