### PR TITLE
MapExpr supports concat op, WIP MapExpr2Ir

### DIFF
--- a/paddle/cinn/adt/CMakeLists.txt
+++ b/paddle/cinn/adt/CMakeLists.txt
@@ -4,6 +4,8 @@ gather_srcs(
   cinnapi_src
   SRCS
   anchor_sd_equation_context.cc
+  dim_expr_simplifier.cc
+  dim_expr.cc
   equation_function.cc
   equation_solver.cc
   equation_value.cc
@@ -17,6 +19,7 @@ gather_srcs(
   naive_bidirection_equation_generator.cc
   naive_op_equation_context.cc
   partition_op_stmts.cc
+  print_dim_expr.cc
   print_equations.cc
   print_map_expr.cc
   print_schedule_descriptor.cc
@@ -26,12 +29,9 @@ gather_srcs(
   schedule_descriptor.cc
   schedule_dim.cc
   schedule_mesh.cc
-  dim_expr.cc
-  dim_expr_simplifier.cc
-  symbolic_dim_infer_util.cc
   simplify_value.cc
-  write_broadcast_disabled_bidirection_equation_generator.cc
-  print_dim_expr.cc)
+  symbolic_dim_infer_util.cc
+  write_broadcast_disabled_bidirection_equation_generator.cc)
 
 cinn_cc_test(equation_value_match_trait_test SRCS
              equation_value_match_trait_test.cc DEPS gtest glog)

--- a/paddle/cinn/adt/equation_function.h
+++ b/paddle/cinn/adt/equation_function.h
@@ -106,19 +106,27 @@ struct GetBroadcastedIterator<DimExpr, tOut<Iterator>, tIn<Iterator>>
   using Tuple<DimExpr, tOut<Iterator>, tIn<Iterator>>::Tuple;
 };
 
+template <typename DimT, typename OutT, typename InT>
+struct SubFunction;
+
+template <>
+struct SubFunction<DimExpr, tOut<Iterator>, tIn<Iterator>>
+    : public Tuple<DimExpr, tOut<Iterator>, tIn<Iterator>> {
+  using Tuple<DimExpr, tOut<Iterator>, tIn<Iterator>>::Tuple;
+};
+
 // clang-format off
 DEFINE_ADT_UNION(Equation,
                  Identity<tOut<Iterator>, tIn<Iterator>>,
                  Identity<tOut<Index>, tIn<Index>>,
                  GetBroadcastedIterator<DimExpr,
                                         tOut<Iterator>, tIn<Iterator>>,
-                 IndexDot<List<DimExpr>, tOut<Index>,
-                          tIn<List<Iterator>>>,
-                 IndexUnDot<List<DimExpr>,
-                            tOut<List<Iterator>>, tIn<Index>>,
+                 SubFunction<DimExpr, tOut<Iterator>, tIn<Iterator>>,
+                 IndexDot<List<DimExpr>, tOut<Index>, tIn<List<Iterator>>>,
+                 IndexUnDot<List<DimExpr>, tOut<List<Iterator>>, tIn<Index>>,
                  InMsg2OutMsg<tOut<FakeOpPlaceHolder>,
-                                    tOut<OpArgIndexes<std::optional<Index>>>,
-                                    tIn<OpArgIndexes<Index>>>,
+                                   tOut<OpArgIndexes<std::optional<Index>>>,
+                                   tIn<OpArgIndexes<Index>>>,
                  ConstantFunction<tOut<Iterator>, tIn<Index>>);
 // clang-format on
 

--- a/paddle/cinn/adt/equation_solver.cc
+++ b/paddle/cinn/adt/equation_solver.cc
@@ -85,8 +85,16 @@ std::unordered_map<Variable, Value> InferValuesImpl(
 }
 
 std::unordered_map<Variable, Value> InferValuesImpl(
-    const IndexUnDot<List<DimExpr>, tOut<List<Iterator>>, tIn<Index>>&
-        undot,
+    const SubFunction<DimExpr, tOut<Iterator>, tIn<Iterator>>& sub,
+    IndexExprInferContext* ctx) {
+  const auto& [dim, out_iterator, in_iterator] = sub.tuple();
+  SubValue<Value, DimExpr> sub_iterator{ctx->GetValue(in_iterator.value()),
+                                        dim};
+  return {{out_iterator.value(), sub_iterator}};
+}
+
+std::unordered_map<Variable, Value> InferValuesImpl(
+    const IndexUnDot<List<DimExpr>, tOut<List<Iterator>>, tIn<Index>>& undot,
     IndexExprInferContext* ctx) {
   const auto& [dims, out_iters, in_index] = undot.tuple();
 
@@ -94,8 +102,8 @@ std::unordered_map<Variable, Value> InferValuesImpl(
   for (const auto& dim : *dims) {
     dim_constants->emplace_back(dim);
   }
-  IndexUnDotValue<Value, List<DimExpr>> index_undot{ctx->GetValue(in_index.value()),
-                                               dim_constants};
+  IndexUnDotValue<Value, List<DimExpr>> index_undot{
+      ctx->GetValue(in_index.value()), dim_constants};
 
   std::unordered_map<Variable, Value> ret{};
   for (std::size_t idx = 0; idx < out_iters.value()->size(); ++idx) {

--- a/paddle/cinn/adt/equation_value.h
+++ b/paddle/cinn/adt/equation_value.h
@@ -68,6 +68,13 @@ struct BroadcastedIterator final : public Tuple<ValueT, ConstantT> {
   const ValueT& GetArg0() const { return std::get<0>(this->tuple()); }
 };
 
+template <typename ValueT, typename ConstantT>
+struct SubValue final : public Tuple<ValueT, ConstantT> {
+  using Tuple<ValueT, ConstantT>::Tuple;
+
+  const ValueT& GetArg0() const { return std::get<0>(this->tuple()); }
+};
+
 DEFINE_ADT_UNION(Value,
                  Undefined,
                  Ok,
@@ -76,6 +83,7 @@ DEFINE_ADT_UNION(Value,
                  List<Value>,
                  IndexDotValue<Value, List<DimExpr>>,
                  IndexUnDotValue<Value, List<DimExpr>>,
+                 SubValue<Value, DimExpr>,
                  ListGetItem<Value, DimExpr>,
                  BroadcastedIterator<Value, DimExpr>,
                  PtrGetItem<Value>);
@@ -89,6 +97,8 @@ using ListGetItem_Value_DimExpr = ListGetItem<Value, DimExpr>;
 OVERLOAD_OPERATOR_EQ_NE(ListGetItem_Value_DimExpr, TupleEqual);
 using BroadcastedIterator_Value_DimExpr = BroadcastedIterator<Value, DimExpr>;
 OVERLOAD_OPERATOR_EQ_NE(BroadcastedIterator_Value_DimExpr, TupleEqual);
+using SubValue_Value_DimExpr = SubValue<Value, DimExpr>;
+OVERLOAD_OPERATOR_EQ_NE(SubValue_Value_DimExpr, TupleEqual);
 OVERLOAD_OPERATOR_EQ_NE(PtrGetItem<Value>, TupleEqual);
 
 inline std::size_t GetHashValue(const Value& value);
@@ -132,6 +142,10 @@ inline std::size_t GetHashValueImpl(const ListGetItem<Value, DimExpr>& value) {
 }
 inline std::size_t GetHashValueImpl(
     const BroadcastedIterator<Value, DimExpr>& value) {
+  const auto& [v, c] = value.tuple();
+  return hash_combine(GetHashValue(v), GetHashValue(c));
+}
+inline std::size_t GetHashValueImpl(const SubValue<Value, DimExpr>& value) {
   const auto& [v, c] = value.tuple();
   return hash_combine(GetHashValue(v), GetHashValue(c));
 }

--- a/paddle/cinn/adt/equation_value_match_trait.h
+++ b/paddle/cinn/adt/equation_value_match_trait.h
@@ -47,37 +47,38 @@ struct MatchTrait<Value, List<T>> final {
   }
 };
 
-#define DEFINE_MATCH_TRAIT_VALUE_UNION_ARGSIZE_2(name, type0, type1)          \
-  template <typename T0, typename T1>                                         \
-  struct MatchTrait<Value, name<T0, T1>> final {                              \
-    using base_type = name<type0, type1>;                                     \
-                                                                              \
-    static constexpr int is_template = true;                                  \
-                                                                              \
-    template <template <typename, typename> class Matcher>                              \
-    static bool MatchChildren(const base_type& value) {                       \
+#define DEFINE_MATCH_TRAIT_VALUE_UNION_ARGSIZE_2(name, type0, type1) \
+  template <typename T0, typename T1>                                \
+  struct MatchTrait<Value, name<T0, T1>> final {                     \
+    using base_type = name<type0, type1>;                            \
+                                                                     \
+    static constexpr int is_template = true;                         \
+                                                                     \
+    template <template <typename, typename> class Matcher>           \
+    static bool MatchChildren(const base_type& value) {              \
       return Matcher<T0, type0>::Call(std::get<0>(value.tuple())) && \
              Matcher<T1, type1>::Call(std::get<1>(value.tuple()));   \
-    }                                                                         \
+    }                                                                \
   };
 
 DEFINE_MATCH_TRAIT_VALUE_UNION_ARGSIZE_2(ListGetItem, Value, DimExpr);
 DEFINE_MATCH_TRAIT_VALUE_UNION_ARGSIZE_2(BroadcastedIterator, Value, DimExpr);
+DEFINE_MATCH_TRAIT_VALUE_UNION_ARGSIZE_2(SubValue, Value, DimExpr);
 DEFINE_MATCH_TRAIT_VALUE_UNION_ARGSIZE_2(IndexDotValue, Value, List<DimExpr>);
 DEFINE_MATCH_TRAIT_VALUE_UNION_ARGSIZE_2(IndexUnDotValue, Value, List<DimExpr>);
 #undef DEFINE_MATCH_TRAIT_VALUE_UNION_ARGSIZE_2
 
-#define DEFINE_ADT_MATCH_TRAIT_EQUATION(name)                              \
-  template <typename T>                                                    \
-  struct MatchTrait<Value, name<T>> final {                                \
-    using base_type = name<Value>;                                         \
-                                                                           \
-    static constexpr int is_template = true;                               \
-                                                                           \
-    template <template <typename, typename> class Matcher>                           \
-    static bool MatchChildren(const base_type& value) {                    \
+#define DEFINE_ADT_MATCH_TRAIT_EQUATION(name)                     \
+  template <typename T>                                           \
+  struct MatchTrait<Value, name<T>> final {                       \
+    using base_type = name<Value>;                                \
+                                                                  \
+    static constexpr int is_template = true;                      \
+                                                                  \
+    template <template <typename, typename> class Matcher>        \
+    static bool MatchChildren(const base_type& value) {           \
       return Matcher<T, Value>::Call(std::get<0>(value.tuple())); \
-    }                                                                      \
+    }                                                             \
   };
 
 DEFINE_ADT_MATCH_TRAIT_EQUATION(PtrGetItem);

--- a/paddle/cinn/adt/m_ir.cc
+++ b/paddle/cinn/adt/m_ir.cc
@@ -82,9 +82,15 @@ void CollectTensorIndexIteratorsImpl(
 }
 
 void CollectTensorIndexIteratorsImpl(
-    const BroadcastedIterator<Value, DimExpr>& broadcasted_iterator,
+    const BroadcastedIterator<Value, DimExpr>& tensor_index_expr,
     std::unordered_set<Iterator>* ret) {
-  CollectTensorIndexIterators(broadcasted_iterator.GetArg0(), ret);
+  CollectTensorIndexIterators(tensor_index_expr.GetArg0(), ret);
+}
+
+void CollectTensorIndexIteratorsImpl(
+    const SubValue<Value, DimExpr>& tensor_index_expr,
+    std::unordered_set<Iterator>* ret) {
+  CollectTensorIndexIterators(tensor_index_expr.GetArg0(), ret);
 }
 
 void CollectTensorIndexIteratorsImpl(const PtrGetItem<Value>& tensor_index_expr,

--- a/paddle/cinn/adt/op_equation_context.h
+++ b/paddle/cinn/adt/op_equation_context.h
@@ -19,8 +19,8 @@
 
 #include "glog/logging.h"
 #include "paddle/cinn/adt/adt.h"
-#include "paddle/cinn/adt/equation.h"
 #include "paddle/cinn/adt/dim_expr.h"
+#include "paddle/cinn/adt/equation.h"
 #include "paddle/cinn/hlir/framework/node.h"
 
 namespace cinn::adt::config {
@@ -43,8 +43,13 @@ class OpEquationContext {
 
   virtual void Equal(const IteratorTuple& lhs, const IteratorTuple& rhs) = 0;
 
-  virtual Iterator GetBroadcastedInputIterator(const Iterator& out_iterator,
-                                               const DimExpr& dim) = 0;
+  virtual Iterator GetBroadcastedInputIterator(
+      const Iterator& out_tensor_iterator, const DimExpr& dim) = 0;
+
+  virtual Iterator Sub(const Iterator& out_tensor_iterator,
+                       const DimExpr& dim) = 0;
+
+  virtual Iterator Identity(const Iterator& iterator) = 0;
 
   virtual const IteratorTuple& GetInIteratorTuple(
       std::size_t input_idx) const = 0;
@@ -64,6 +69,8 @@ class OpEquationContext {
   const T& Attr(const std::string& name) const {
     return absl::get<T>(GetAttribute(name));
   }
+
+  virtual bool HasAttr(const std::string& name) const = 0;
 
  protected:
   OpEquationContext() = default;

--- a/paddle/cinn/adt/print_equations.cc
+++ b/paddle/cinn/adt/print_equations.cc
@@ -185,8 +185,17 @@ struct ToTxtStringStruct {
   }
 
   std::string operator()(
-      const IndexUnDot<List<DimExpr>, tOut<List<Iterator>>, tIn<Index>>&
-          undot) const {
+      const SubFunction<DimExpr, tOut<Iterator>, tIn<Iterator>>& sub) const {
+    std::string ret;
+    const auto& [dim, out_iterator, in_iterator] = sub.tuple();
+    ret += ToTxtString(out_iterator.value()) + " = Sub(" +
+           ToTxtString(in_iterator.value()) + ", " + ToTxtString(dim) + ")";
+    return ret;
+  }
+
+  std::string operator()(
+      const IndexUnDot<List<DimExpr>, tOut<List<Iterator>>, tIn<Index>>& undot)
+      const {
     std::string ret;
     const auto& [dim_list, out_iterator_list_tag, in_index_tag] = undot.tuple();
     const List<Iterator>& out_iterator_list = out_iterator_list_tag.value();

--- a/paddle/cinn/adt/print_value.cc
+++ b/paddle/cinn/adt/print_value.cc
@@ -83,11 +83,17 @@ struct ToTxtStringStruct {
     return ret;
   }
 
-  std::string operator()(
-      const BroadcastedIterator<Value, DimExpr>& broadcast) {
+  std::string operator()(const BroadcastedIterator<Value, DimExpr>& broadcast) {
     std::string ret;
     const auto& [value, constant] = broadcast.tuple();
     ret += "BI(" + ToTxtString(value) + ", " + ToTxtString(constant) + ")";
+    return ret;
+  }
+
+  std::string operator()(const SubValue<Value, DimExpr>& sub_value) {
+    std::string ret;
+    const auto& [value, constant] = sub_value.tuple();
+    ret += "(" + ToTxtString(value) + " - " + ToTxtString(constant) + ")";
     return ret;
   }
 

--- a/test/cinn/adt/test_naive_concat.py
+++ b/test/cinn/adt/test_naive_concat.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from cinn.common import DefaultNVGPUTarget, Float
+from cinn.frontend import NetBuilder
+
+
+class TestMapExprNaiveAdd(unittest.TestCase):
+    def setUp(self):
+        self.inputs = {
+            "x": np.random.uniform(-1.0, 1.0, [64, 16]).astype("float32"),
+            "y": np.random.uniform(-1.0, 1.0, [64, 16]).astype("float32"),
+        }
+
+    def test_naive_add(self):
+        builder = NetBuilder("TestMapExprNaiveAdd")
+        x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
+        y = builder.create_input(Float(32), self.inputs["y"].shape, "y")
+
+        x = builder.relu(x)
+        y = builder.relu(y)
+        out = builder.concat([x, y], axis=1)
+        prog = builder.build()
+        target = DefaultNVGPUTarget()
+
+        result = prog.build_and_get_output(
+            target,
+            [x, y],
+            [self.inputs["x"], self.inputs["y"]],
+            [out],
+            passes=[],
+            scope=None,
+        )
+
+        # np.testing.assert_allclose(
+        #     result[0].numpy(target),
+        #     np.concatenate((self.inputs["x"], self.inputs["y"]), axis=1),
+        #     err_msg="TestMapExprNaiveAdd failed!",
+        # )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<img width="447" alt="b3766af5d6b700bc419bc2301e3c5e8b" src="https://github.com/jiahy0825/Paddle/assets/17810795/66dc4f4a-00b4-44e6-8353-4d5f9b144030">


Corner case:
前端的 fusion pass 会将其拆分为两个 Group

```
        x = builder.relu(x)
        y = builder.elementwise_add(x, y)
        out = builder.concat([x, y], axis=1)
```
<img width="310" alt="image" src="https://github.com/jiahy0825/Paddle/assets/17810795/1209c2c7-ba15-4688-8851-c563d5612c2c">

```
__global__
void __launch_bounds__(1024) fn_fill_constant_0_max_1_3_kernel(const float* __restrict__ x, float* __restrict__ var_1)
{
  if (((int)threadIdx.x < 1024)) {
    var_1[(int)threadIdx.x] = max(x[(int)threadIdx.x], 0.00000000f);
  };
}
```

<img width="297" alt="image" src="https://github.com/jiahy0825/Paddle/assets/17810795/dac7063c-2259-451f-84a7-3bf9631340c8">

```
__global__
void __launch_bounds__(1024) fn_elementwise_add_2_concat_3_4_kernel(const float* __restrict__ var_1, const float* __restrict__ y, float* __restrict__ var_3)
{
  if (((int)blockIdx.x < 2)) {
    if (((int)threadIdx.x < 1024)) {
      var_3[((1024 * (int)blockIdx.x) + (int)threadIdx.x)] = ((((((1024 * (int)blockIdx.x) + (int)threadIdx.x) & 31) < 16)) ? var_1[((16 * ((int)threadIdx.x / 32)) + (((int)threadIdx.x & 31) + (512 * (int)blockIdx.x)))] : (var_1[(-16 + ((16 * ((int)threadIdx.x / 32)) + (((int)threadIdx.x & 31) + (512 * (int)blockIdx.x))))] + y[(-16 + ((16 * ((int)threadIdx.x / 32)) + (((int)threadIdx.x & 31) + (512 * (int)blockIdx.x))))]));
    };
  };
}
```